### PR TITLE
CFT-3558: Added an option to specify an auth endpoint

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,8 +65,7 @@ jobs:
       - name: Deploy-Ready check
         id: deploy_ready
         run: |
-          if [[ "${{ steps.default_branch.outputs.is_default_branch }}" == "true" \
-            && "${{ github.ref }}" == refs/tags/* \
+          if [[ "${{ github.ref }}" == refs/tags/* \
             && "${{ steps.tag.outputs.is_semantic_tag }}" == "true" ]]; then
               echo "is_deploy_ready=true" | tee -a $GITHUB_OUTPUT
           else

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Configuration - component configuration level:
 - tenant_id (Required) - Your FranConnect tenant identifier
 - client_id (Required) - OAuth client ID
 - client_secret (Required) - OAuth client secret (stored securely)
+- auth_endpoint (Optional) - FranConnect authentication endpoint (Default: https://auth.franconnect.net/userauth/oauth/token)
 
 Configuration - configuration row level:
 =============

--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -29,6 +29,13 @@
           "format": "password",
           "propertyOrder": 13
         },
+        "auth_endpoint": {
+          "type": "string",
+          "title": "Auth Endpoint",
+          "description": "Auth endpoint for FranConnect Credentials",
+          "default": "https://auth.franconnect.net/userauth/oauth/token",
+          "propertyOrder": 14
+        },
         "test_connection": {
           "type": "button",
           "format": "test-connection"

--- a/src/client/franconnect.py
+++ b/src/client/franconnect.py
@@ -11,18 +11,18 @@ BATCHE_SIZE = 100
 
 class FranConnectClient(HttpClient):
 
-    def __init__(self, tenant_id, client_id, client_secret):
+    def __init__(self, tenant_id, client_id, client_secret, auth_endpoint):
         super().__init__(base_url=f"https://{tenant_id}")
-        token = self.get_auth_token(tenant_id, client_id, client_secret)
+        token = self.get_auth_token(tenant_id, client_id, client_secret, auth_endpoint)
         self.update_auth_header({"Authorization": f"Bearer {token}"})
 
-    def get_auth_token(self, tenant_id: str, client_id: str, client_secret: str):
+    def get_auth_token(self, tenant_id: str, client_id: str, client_secret: str, auth_endpoint: str):
         auth_str = f"{client_id}:{client_secret}"
         basic_auth = base64.b64encode(auth_str.encode()).decode()
         headers = {"Authorization": f"Basic {basic_auth}"}
 
         response = self.post(
-            endpoint_path="https://auth.franconnect.net/userauth/oauth/token",
+            endpoint_path=auth_endpoint,
             headers=headers,
             data={"grant_type": "client_credentials", "X-TenantID": tenant_id},
             is_absolute_path=True

--- a/src/component.py
+++ b/src/component.py
@@ -63,7 +63,7 @@ class Component(ComponentBase):
 
     def init_client(self):
         self.client = FranConnectClient(self.params.credentials.tenant_id, self.params.credentials.client_id,
-                                        self.params.credentials.client_secret)
+                                        self.params.credentials.client_secret, self.params.credentials.auth_endpoint)
 
     @sync_action("testConnection")
     def test_connection(self):

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -2,6 +2,7 @@ from enum import Enum
 from pydantic import BaseModel, Field, ValidationError, computed_field
 from keboola.component.exceptions import UserException
 
+default_auth_endpoint = "https://auth.franconnect.net/userauth/oauth/token"
 
 class LoadType(str, Enum):
     full_load = "full_load"
@@ -12,6 +13,7 @@ class Credentials(BaseModel):
     tenant_id: str = Field()
     client_id: str = Field()
     client_secret: str = Field(alias="#client_secret")
+    auth_endpoint: str = Field(default=default_auth_endpoint)
 
 
 class Source(BaseModel):

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -4,6 +4,7 @@ from keboola.component.exceptions import UserException
 
 default_auth_endpoint = "https://auth.franconnect.net/userauth/oauth/token"
 
+
 class LoadType(str, Enum):
     full_load = "full_load"
     incremental_load = "incremental_load"


### PR DESCRIPTION
## Description

There is a client that would utilize the connector, but their auth endpoint is available on a different resource. This change introduces an option to add a custom auth endpoint while keeping the original one as a default one.