### PR TITLE
chore(deps): AJDA-2973 bump keboola-component to ==1.11.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-keboola.component==1.6.10
+keboola.component==1.11.0
 keboola.utils==1.1.0
 keboola.http-client==1.0.1
 requests==2.32.3


### PR DESCRIPTION
## Link to issue
https://linear.app/keboola/issue/AJDA-2973

## Description
Bumps the pinned `keboola-component` dependency from `keboola.component==1.6.10` to `==1.11.0` in `requirements.txt`. Version 1.11.0 scopes the manifest schema/legacy-columns exclusivity guard to output manifests only, so the component can read input tables that carry both a native `schema` node and legacy `columns`/`metadata` keys. (This repo pins requirements directly; there is no separate lockfile to regenerate.)

## Justification
Aligns this component with the platform-wide `keboola-component` 1.11.0 rollout (see AJDA-2973); it was pinned to an old version affected by the input-manifest bug.

## Plans for Customer Communication
None.

## Impact Analysis
Dependency-only change. Backward compatible — existing manifest precedence rules are preserved. No feature flag.

## Deployment Plan
Standard CI/CD — image is published from the merge commit and ArgoCD picks it up.

## Rollback Plan
Revert this PR, or roll back to the previous image tag in ArgoGitops.

## Post-Release Support Plan
None.
